### PR TITLE
Implement turn-based battles with data assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@ discord/
 discord-2.0.0.dist-info/
 discord.py-2.0.1.dist-info/
 __pycache__/
-data/
+data/users/*.json
+!data/users/.gitkeep
 token
 bujo.txt
 fiverr readme.txt

--- a/battle.py
+++ b/battle.py
@@ -1,0 +1,744 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import discord
+
+from discobot_modules import emoji_actions
+from discobot_modules.emoji_actions import Emoji_Action, ea_response
+
+from db import ITEMS
+
+import classes
+import moves
+import embeds
+import users
+import economy
+
+
+@dataclass
+class BattleParticipant:
+    user_id: Optional[int]
+    name: str
+    party: Sequence[classes.Individual]
+
+
+@dataclass
+class QueuedAction:
+    kind: str
+    move: Optional[moves.Move] = None
+    switch_index: Optional[int] = None
+    item_key: Optional[str] = None
+    flee: bool = False
+
+
+@dataclass
+class BattlePokemonState:
+    individual: classes.Individual
+    current_hp: int = field(init=False)
+    status: Optional[str] = None
+    status_turns: int = 0
+    participated: bool = False
+
+    def __post_init__(self) -> None:
+        self.current_hp = self.individual.max_hp()
+
+    def max_hp(self) -> int:
+        return self.individual.max_hp()
+
+    def is_fainted(self) -> bool:
+        return self.current_hp <= 0
+
+    def apply_damage(self, amount: int) -> int:
+        amount = max(0, int(amount))
+        if amount <= 0:
+            return 0
+        self.current_hp = max(0, self.current_hp - amount)
+        return amount
+
+    def heal(self, amount: int) -> int:
+        amount = max(0, int(amount))
+        before = self.current_hp
+        self.current_hp = min(self.max_hp(), self.current_hp + amount)
+        return self.current_hp - before
+
+    def set_status(self, kind: Optional[str]) -> None:
+        if kind is None:
+            self.status = None
+            self.status_turns = 0
+            return
+        if kind == "sleep":
+            self.status = kind
+            self.status_turns = random.randint(1, 3)
+        else:
+            self.status = kind
+            self.status_turns = -1
+
+    def status_text(self) -> str:
+        if not self.status:
+            return ""
+        if self.status == "burn":
+            return "BRN"
+        if self.status == "paralysis":
+            return "PAR"
+        if self.status == "poison":
+            return "PSN"
+        if self.status == "sleep":
+            return "SLP"
+        return self.status.upper()
+
+
+@dataclass
+class BattleSide:
+    participant: BattleParticipant
+    team: List[BattlePokemonState]
+    active_index: int = 0
+    selection_mode: str = "menu"
+    queued_action: Optional[QueuedAction] = None
+
+    def active(self) -> BattlePokemonState:
+        return self.team[self.active_index]
+
+    def alive_indices(self) -> List[int]:
+        return [idx for idx, mon in enumerate(self.team) if not mon.is_fainted()]
+
+    def has_available_switch(self) -> bool:
+        return any(idx != self.active_index and not mon.is_fainted() for idx, mon in enumerate(self.team))
+
+    def force_next_available(self) -> bool:
+        for idx, mon in enumerate(self.team):
+            if idx == self.active_index:
+                continue
+            if not mon.is_fainted():
+                self.active_index = idx
+                self.selection_mode = "menu"
+                self.queued_action = None
+                return True
+        return False
+
+
+@dataclass
+class BattleResult:
+    participants: Tuple[BattleParticipant, BattleParticipant]
+    winner: Optional[int]
+    rounds: int
+    log: List[str] = field(default_factory=list)
+    battle_type: str = "wild"
+    rewards: Dict[int, int] = field(default_factory=dict)
+    experience_log: Dict[int, List[str]] = field(default_factory=dict)
+
+
+ACTIVE_SESSIONS: Dict[int, "BattleSession"] = {}
+
+
+class BattleSession:
+    MENU_EMOJIS = {"⚔️": "attack", "🔄": "switch", "🧴": "item", "🏃": "run"}
+    NUMBER_EMOJIS = ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣"]
+
+    def __init__(
+        self,
+        channel: discord.abc.Messageable,
+        challenger: BattleParticipant,
+        opponent: BattleParticipant,
+        battle_type: str = "trainer",
+    ) -> None:
+        self.channel = channel
+        self.participants = (challenger, opponent)
+        self.battle_type = battle_type
+        self.sides = [
+            BattleSide(challenger, [BattlePokemonState(mon) for mon in challenger.party]),
+            BattleSide(opponent, [BattlePokemonState(mon) for mon in opponent.party]),
+        ]
+        self.turn = 1
+        self.log: List[str] = []
+        self.message: Optional[discord.Message] = None
+        self.pending_actions: List[Optional[QueuedAction]] = [None, None]
+        self.selection_modes: List[str] = ["menu", "menu"]
+        self.item_options: Dict[int, List[str]] = {0: [], 1: []}
+        self.experience_log: Dict[int, List[str]] = {}
+        self.finished = False
+        self.winner: Optional[int] = None
+        self.rewards: Dict[int, int] = {}
+        self.participation: List[set[int]] = [set(), set()]
+
+    @property
+    def challenger(self) -> BattleSide:
+        return self.sides[0]
+
+    @property
+    def opponent(self) -> BattleSide:
+        return self.sides[1]
+
+    async def start(self) -> None:
+        for idx, side in enumerate(self.sides):
+            if not side.alive_indices():
+                raise ValueError("Battle cannot start with empty parties.")
+            first_alive = side.alive_indices()[0]
+            side.active_index = first_alive
+        embed = self._build_live_embed()
+        self.message = await self.channel.send(embed=embed)
+        ACTIVE_SESSIONS[self.message.id] = self
+        await self._register_actions()
+        await self._ensure_ai_actions()
+        await self._refresh_interface()
+
+    async def _register_actions(self) -> None:
+        if not self.message:
+            return
+        actions: List[Emoji_Action] = []
+        for emoji, action in self.MENU_EMOJIS.items():
+            actions.append(Emoji_Action(emoji, action, _menu_callback, args=(self, action), pass_user=True))
+        for idx, emoji in enumerate(self.NUMBER_EMOJIS):
+            actions.append(Emoji_Action(emoji, f"option_{idx+1}", _number_callback, args=(self, idx), pass_user=True))
+        await self.message.clear_reactions()
+        emoji_actions.active_actions[str(self.message.id)] = []
+        await emoji_actions.action_button_list(self.message, actions)
+
+    def _side_index_for_user(self, user_id: int) -> Optional[int]:
+        for idx, participant in enumerate(self.participants):
+            if participant.user_id == user_id:
+                return idx
+        return None
+
+    async def on_menu_action(self, action: str, user: discord.User) -> ea_response:
+        if self.finished:
+            return ea_response(complete_action=False)
+        side_index = self._side_index_for_user(user.id)
+        if side_index is None:
+            return ea_response(complete_action=False)
+        side = self.sides[side_index]
+        if side.participant.user_id is None:
+            return ea_response(complete_action=False)
+        if side.selection_mode != "menu":
+            await self.channel.send(f"{side.participant.name}, finish your current selection first!", delete_after=10)
+            return ea_response(complete_action=False)
+        if action == "attack":
+            side.selection_mode = "move"
+            await self.channel.send(f"{side.participant.name}, choose a move with the number reactions!", delete_after=10)
+        elif action == "switch":
+            if not side.has_available_switch():
+                await self.channel.send(f"{side.participant.name}, there are no healthy Pokémon to switch to.", delete_after=10)
+            else:
+                side.selection_mode = "switch"
+                await self.channel.send(f"{side.participant.name}, pick a party slot to switch in.", delete_after=10)
+        elif action == "item":
+            options = self._battle_items_for_user(side.participant.user_id)
+            if not options:
+                await self.channel.send(f"{side.participant.name}, you don't have any usable battle items.", delete_after=10)
+            else:
+                self.item_options[side_index] = options
+                side.selection_mode = "item"
+                lines = [f"{idx + 1}. {ITEMS[key]['name']}" for idx, key in enumerate(options)]
+                await self.channel.send(f"{side.participant.name}, choose an item:\n" + "\n".join(lines), delete_after=15)
+        elif action == "run":
+            if self.battle_type == "trainer":
+                await self.channel.send("You can't run from a trainer battle!", delete_after=10)
+            else:
+                self.pending_actions[side_index] = QueuedAction("run", flee=True)
+                side.selection_mode = "ready"
+                await self._maybe_resolve_turn()
+        await self._refresh_interface()
+        return ea_response(complete_action=False)
+
+    async def on_number_selection(self, index: int, user: discord.User) -> ea_response:
+        if self.finished:
+            return ea_response(complete_action=False)
+        side_index = self._side_index_for_user(user.id)
+        if side_index is None:
+            return ea_response(complete_action=False)
+        side = self.sides[side_index]
+        mode = side.selection_mode
+        if mode == "move":
+            await self._queue_move(side_index, index)
+        elif mode == "switch":
+            await self._queue_switch(side_index, index)
+        elif mode == "item":
+            await self._queue_item(side_index, index)
+        else:
+            return ea_response(complete_action=False)
+        await self._refresh_interface()
+        return ea_response(complete_action=False)
+
+    async def _queue_move(self, side_index: int, index: int) -> None:
+        side = self.sides[side_index]
+        moveset = side.active().individual.get_move_objects()
+        if index >= len(moveset):
+            await self.channel.send(f"{side.participant.name}, that move slot is empty.", delete_after=10)
+            return
+        move = moveset[index]
+        side.selection_mode = "ready"
+        side.queued_action = QueuedAction("move", move=move)
+        self.pending_actions[side_index] = side.queued_action
+        side.active().participated = True
+        self.participation[side_index].add(side.active_index)
+        await self.channel.send(f"{side.participant.name} queued {move.name}!", delete_after=8)
+        await self._maybe_resolve_turn()
+
+    async def _queue_switch(self, side_index: int, index: int) -> None:
+        side = self.sides[side_index]
+        slot = index
+        if slot < 0 or slot >= len(side.team):
+            await self.channel.send("That party slot doesn't exist yet.", delete_after=10)
+            return
+        if side.team[slot].is_fainted():
+            await self.channel.send("That Pokémon has fainted and can't battle.", delete_after=10)
+            return
+        if slot == side.active_index:
+            await self.channel.send("They're already in battle!", delete_after=10)
+            return
+        side.selection_mode = "ready"
+        action = QueuedAction("switch", switch_index=slot)
+        side.queued_action = action
+        self.pending_actions[side_index] = action
+        await self.channel.send(f"{side.participant.name} will switch to slot {slot + 1}.", delete_after=8)
+        await self._maybe_resolve_turn()
+
+    async def _queue_item(self, side_index: int, index: int) -> None:
+        options = self.item_options.get(side_index) or []
+        if index >= len(options):
+            await self.channel.send("That item option isn't available.", delete_after=10)
+            return
+        item_key = options[index]
+        side = self.sides[side_index]
+        action = QueuedAction("item", item_key=item_key)
+        side.selection_mode = "ready"
+        side.queued_action = action
+        self.pending_actions[side_index] = action
+        try:
+            item_record = ITEMS[item_key]
+        except FileNotFoundError:
+            item_record = {"name": item_key.title()}
+        item_name = item_record.get("name", item_key.title())
+        await self.channel.send(f"{side.participant.name} readies a {item_name}!", delete_after=8)
+        await self._maybe_resolve_turn()
+
+    async def _ensure_ai_actions(self) -> None:
+        for idx, side in enumerate(self.sides):
+            if side.participant.user_id is not None:
+                continue
+            if self.pending_actions[idx] is None and not self.finished:
+                await self._queue_ai_action(idx)
+
+    async def _queue_ai_action(self, side_index: int) -> None:
+        side = self.sides[side_index]
+        attacker = side.active()
+        moveset = attacker.individual.get_move_objects()
+        move = None
+        if moveset:
+            move = max(moveset, key=lambda m: m.power)
+        if not move:
+            move = moves.get("tackle")
+        action = QueuedAction("move", move=move)
+        side.queued_action = action
+        self.pending_actions[side_index] = action
+        attacker.participated = True
+        self.participation[side_index].add(side.active_index)
+
+    async def _maybe_resolve_turn(self) -> None:
+        await self._ensure_ai_actions()
+        if all(action is not None for action in self.pending_actions):
+            await self._resolve_turn()
+
+    async def _resolve_turn(self) -> None:
+        if self.finished:
+            return
+        actions: List[Tuple[int, QueuedAction]] = []
+        for idx, action in enumerate(self.pending_actions):
+            if action is not None:
+                actions.append((idx, action))
+        order = sorted(actions, key=lambda entry: self._action_order_key(*entry), reverse=True)
+        turn_log: List[str] = []
+        for side_index, action in order:
+            if self.finished:
+                break
+            side = self.sides[side_index]
+            if action.kind == "move":
+                entry = self._execute_move(side_index, action.move)
+                if entry:
+                    turn_log.append(entry)
+            elif action.kind == "switch":
+                entry = self._execute_switch(side_index, action.switch_index)
+                if entry:
+                    turn_log.append(entry)
+            elif action.kind == "item":
+                entry = self._execute_item(side_index, action.item_key)
+                if entry:
+                    turn_log.append(entry)
+            elif action.kind == "run":
+                self.finished = True
+                self.winner = 1 - side_index
+                turn_log.append(f"{self.sides[side_index].participant.name} fled the battle!")
+        self.turn += 1
+        for idx in range(len(self.sides)):
+            if self.finished:
+                break
+            status_entry = self._apply_end_of_turn_status(idx)
+            if status_entry:
+                turn_log.append(status_entry)
+        self.pending_actions = [None, None]
+        for side in self.sides:
+            if side.selection_mode != "switch":
+                side.selection_mode = "menu"
+            side.queued_action = None
+        self.log.extend(turn_log)
+        if self.finished:
+            await self._conclude_battle()
+        else:
+            await self._refresh_interface(extra_log=turn_log)
+
+    def _action_order_key(self, side_index: int, action: QueuedAction) -> Tuple[int, int, float]:
+        if action.kind == "run":
+            priority = 6
+        elif action.kind == "switch":
+            priority = 5
+        elif action.kind == "item":
+            priority = 4
+        elif action.kind == "move" and action.move:
+            priority = 3 + action.move.priority
+        else:
+            priority = 0
+        speed = self.sides[side_index].active().individual.get_stats()["speed"]
+        return (priority, speed, random.random())
+
+    def _execute_move(self, side_index: int, move: Optional[moves.Move]) -> Optional[str]:
+        side = self.sides[side_index]
+        attacker = side.active()
+        if attacker.is_fainted():
+            return None
+        if attacker.status == "sleep":
+            if attacker.status_turns > 0:
+                attacker.status_turns -= 1
+                if attacker.status_turns <= 0:
+                    attacker.set_status(None)
+                    return f"{attacker.individual.get_title()} woke up!"
+                return f"{attacker.individual.get_title()} is fast asleep!"
+        if attacker.status == "paralysis" and random.random() < 0.25:
+            return f"{attacker.individual.get_title()} is paralyzed! It can't move!"
+        if not move:
+            move = moves.get("tackle")
+        target_index = 1 - side_index
+        defender_side = self.sides[target_index]
+        defender = defender_side.active()
+        damage = self._calculate_damage(attacker, defender, move)
+        healed = 0
+        if damage > 0:
+            defender.apply_damage(damage)
+        if move.heal:
+            healed = attacker.heal(move.heal)
+        entry = f"{attacker.individual.get_title()} used {move.name}!"
+        if damage:
+            entry += f" It dealt {damage} damage."
+        if healed:
+            entry += f" It restored {healed} HP!"
+        if move.status and not defender.is_fainted():
+            if random.random() <= move.status_chance:
+                if defender.status != move.status:
+                    defender.set_status(move.status)
+                    entry += f" {defender.individual.get_title()} is now {defender.status_text()}!"
+        if defender.is_fainted():
+            entry += f" {defender.individual.get_title()} fainted!"
+            faint_message = self._handle_faint(target_index)
+            if faint_message:
+                entry += f" {faint_message}"
+        return entry
+
+    def _execute_switch(self, side_index: int, slot: Optional[int]) -> Optional[str]:
+        if slot is None:
+            return None
+        side = self.sides[side_index]
+        if slot < 0 or slot >= len(side.team):
+            return None
+        side.active_index = slot
+        side.selection_mode = "menu"
+        return f"{side.participant.name} sent out {side.active().individual.get_title()}!"
+
+    def _execute_item(self, side_index: int, item_key: Optional[str]) -> Optional[str]:
+        if not item_key:
+            return None
+        side = self.sides[side_index]
+        uid = side.participant.user_id
+        if uid is None:
+            return None
+        try:
+            item_data = ITEMS[item_key]
+        except FileNotFoundError:
+            return f"{side.participant.name} tried to use an unknown item."
+        if not economy.user_spend_item(uid, item_key, 1):
+            return f"{side.participant.name} tried to use a {item_data['name']}, but didn't have one!"
+        item = item_data
+        heal_amount = int(item.get("battle_heal", 0))
+        healed = side.active().heal(heal_amount)
+        return f"{side.participant.name} used {item['name']} and restored {healed} HP!"
+
+    def _calculate_damage(self, attacker: BattlePokemonState, defender: BattlePokemonState, move: moves.Move) -> int:
+        if move.category == "status" or move.power <= 0:
+            return 0
+        atk_stats = attacker.individual.get_stats()
+        def_stats = defender.individual.get_stats()
+        if move.category == "physical":
+            attack_stat = atk_stats["attack"]
+            if attacker.status == "burn":
+                attack_stat = max(1, int(attack_stat * 0.8))
+            defense_stat = def_stats["defense"]
+        else:
+            attack_stat = atk_stats["sp_attack"]
+            defense_stat = def_stats["sp_defense"]
+        level = attacker.individual.level
+        base = (((2 * level / 5) + 2) * move.power * attack_stat / max(1, defense_stat)) / 50 + 2
+        modifier = random.uniform(0.85, 1.0)
+        stab = 1.0
+        attacker_types = [attacker.individual.species.type_1.name]
+        if attacker.individual.species.type_2:
+            attacker_types.append(attacker.individual.species.type_2.name)
+        if move.type in attacker_types:
+            stab = 1.5
+        damage = int(base * modifier * stab)
+        return max(1, damage)
+
+    def _handle_faint(self, side_index: int) -> Optional[str]:
+        side = self.sides[side_index]
+        if side.participant.user_id is None:
+            if side.force_next_available():
+                self.pending_actions[side_index] = None
+                side.selection_mode = "menu"
+                return None
+        else:
+            if side.has_available_switch():
+                self.pending_actions[side_index] = None
+                side.selection_mode = "switch"
+                return f"{side.participant.name}, choose your next Pokémon!"
+        self.finished = True
+        self.winner = 1 - side_index
+        return None
+
+    def _apply_end_of_turn_status(self, side_index: int) -> Optional[str]:
+        side = self.sides[side_index]
+        active = side.active()
+        if active.is_fainted() or not active.status:
+            return None
+        if active.status == "burn":
+            damage = max(1, active.max_hp() // 16)
+            active.apply_damage(damage)
+            message = f"{active.individual.get_title()} is hurt by its burn! (-{damage} HP)"
+            if active.is_fainted():
+                faint_message = self._handle_faint(side_index)
+                if faint_message:
+                    message += f" {faint_message}"
+            return message
+        if active.status == "poison":
+            damage = max(1, active.max_hp() // 8)
+            active.apply_damage(damage)
+            message = f"{active.individual.get_title()} is hurt by poison! (-{damage} HP)"
+            if active.is_fainted():
+                faint_message = self._handle_faint(side_index)
+                if faint_message:
+                    message += f" {faint_message}"
+            return message
+        return None
+
+    async def _conclude_battle(self) -> None:
+        await self._distribute_rewards_and_xp()
+        self._record_battles()
+        result = BattleResult(
+            participants=self.participants,
+            winner=self.winner,
+            rounds=self.turn,
+            log=self.log,
+            battle_type=self.battle_type,
+            rewards=self.rewards,
+            experience_log=self.experience_log,
+        )
+        if self.message:
+            await self.message.clear_reactions()
+            await self.message.edit(embed=embeds.battle(result))
+            ACTIVE_SESSIONS.pop(self.message.id, None)
+
+    async def _distribute_rewards_and_xp(self) -> None:
+        challenger, opponent = self.sides
+        if self.battle_type == "trainer":
+            if self.winner is None:
+                rewards = {challenger.participant.user_id: 2, opponent.participant.user_id: 2}
+            elif self.winner == 0:
+                rewards = {challenger.participant.user_id: 5, opponent.participant.user_id: 1}
+            else:
+                rewards = {challenger.participant.user_id: 1, opponent.participant.user_id: 5}
+        else:
+            rewards = {}
+            if self.winner == 0:
+                rewards[challenger.participant.user_id] = 3
+            elif self.winner == 1:
+                rewards[opponent.participant.user_id] = 3
+        for uid, amount in rewards.items():
+            if uid is None or amount <= 0:
+                continue
+            users.adjust_bp(uid, amount)
+        self.rewards = {uid: amount for uid, amount in rewards.items() if uid is not None}
+        await self._award_experience()
+
+    def _record_battles(self) -> None:
+        challenger, opponent = self.participants
+        if challenger.user_id:
+            if self.winner is None:
+                outcome = "draw"
+            elif self.winner == 0:
+                outcome = "win"
+            else:
+                outcome = "loss"
+            context = {"type": self.battle_type}
+            if self.battle_type == "trainer" and opponent.user_id:
+                context["opponent"] = opponent.user_id
+            elif self.battle_type == "wild" and opponent.party:
+                wild = opponent.party[0]
+                context.update({"pokemon": wild.species.pokedex_number, "name": wild.species.name})
+            users.record_battle(challenger.user_id, outcome, context)
+        if opponent.user_id:
+            if self.winner is None:
+                outcome = "draw"
+            elif self.winner == 1:
+                outcome = "win"
+            else:
+                outcome = "loss"
+            context = {"type": self.battle_type}
+            if self.battle_type == "trainer" and challenger.user_id:
+                context["opponent"] = challenger.user_id
+            elif self.battle_type == "wild" and challenger.party:
+                wild = challenger.party[0]
+                context.update({"pokemon": wild.species.pokedex_number, "name": wild.species.name})
+            users.record_battle(opponent.user_id, outcome, context)
+
+    async def _award_experience(self) -> None:
+        self.experience_log = {}
+        for idx, side in enumerate(self.sides):
+            participant = side.participant
+            if participant.user_id is None:
+                continue
+            events: List[str] = []
+            xp_gain = self._xp_for_side(idx)
+            if xp_gain <= 0:
+                continue
+            user_record = users.ensure_user_record(participant.user_id)
+            roster = user_record.get("pokemon", [])
+            roster_map = {entry.get("uid"): pos for pos, entry in enumerate(roster)}
+            for mon in side.team:
+                if not mon.participated:
+                    continue
+                uid = mon.individual.instance_id
+                pos = roster_map.get(uid, -1)
+                mon_events = mon.individual.gain_experience(xp_gain)
+                if pos >= 0:
+                    roster[pos] = mon.individual.to_dict()
+                if mon_events["level"] or mon_events["evolution"]:
+                    events.extend([f"{mon.individual.get_title()}: {msg}" for msg in mon_events["level"] + mon_events["evolution"]])
+            user_record["pokemon"] = roster
+            users.USERS[participant.user_id] = user_record
+            users.USERS.save_item(participant.user_id)
+            if events:
+                self.experience_log[participant.user_id] = events
+
+    def _xp_for_side(self, side_index: int) -> int:
+        opponent_index = 1 - side_index
+        defeated_levels = []
+        for mon in self.sides[opponent_index].team:
+            if mon.is_fainted():
+                defeated_levels.append(mon.individual.level)
+        if not defeated_levels:
+            return 0
+        base = sum(level for level in defeated_levels) // max(1, len(defeated_levels))
+        return max(10, base * 5)
+
+    def _battle_items_for_user(self, user_id: Optional[int]) -> List[str]:
+        if user_id is None:
+            return []
+        usable = []
+        for key in ("potion", "superpotion"):
+            try:
+                count = economy.user_item_count(user_id, key)
+            except Exception:
+                count = 0
+            if count > 0:
+                usable.append(key)
+        return usable
+
+    def _build_live_embed(self, extra_log: Optional[Iterable[str]] = None) -> discord.Embed:
+        title = "Trainer Battle" if self.battle_type == "trainer" else "Wild Encounter"
+        embed = discord.Embed(title=title, color=0x5B6EE1 if self.battle_type == "trainer" else 0xE12005)
+        embed.description = f"Turn {self.turn}\nReact with the emojis to choose your action."
+        for idx, side in enumerate(self.sides):
+            active = side.active()
+            hp_line = f"HP: {active.current_hp}/{active.max_hp()}"
+            status = active.status_text()
+            status_text = f" [{status}]" if status else ""
+            moveset = ", ".join(move.name for move in active.individual.get_move_objects())
+            embed.add_field(
+                name=f"{self.participants[idx].name}",
+                value=(
+                    f"{active.individual.get_title()} Lv{active.individual.level}{status_text}\n"
+                    f"{hp_line}\n"
+                    f"Moves: {moveset if moveset else '—'}"
+                ),
+                inline=False,
+            )
+        history = list(extra_log or [])
+        if not history and self.log:
+            history = self.log[-5:]
+        if history:
+            embed.add_field(name="Recent Events", value="\n".join(history[-5:]), inline=False)
+        return embed
+
+    async def _refresh_interface(self, extra_log: Optional[Iterable[str]] = None) -> None:
+        if not self.message or self.finished:
+            return
+        embed = self._build_live_embed(extra_log)
+        await self.message.edit(embed=embed)
+
+
+async def start_trainer_battle(
+    message: discord.Message,
+    challenger_id: int,
+    challenger_name: str,
+    challenger_party: Sequence[classes.Individual],
+    opponent_id: int,
+    opponent_name: str,
+    opponent_party: Sequence[classes.Individual],
+) -> None:
+    challenger = BattleParticipant(challenger_id, challenger_name, challenger_party)
+    opponent = BattleParticipant(opponent_id, opponent_name, opponent_party)
+    session = BattleSession(message.channel, challenger, opponent, "trainer")
+    await session.start()
+
+
+async def start_wild_battle(
+    channel: discord.abc.Messageable,
+    trainer_id: int,
+    trainer_name: str,
+    party: Sequence[classes.Individual],
+    wild: classes.Individual,
+) -> None:
+    challenger = BattleParticipant(trainer_id, trainer_name, party)
+    opponent = BattleParticipant(None, f"Wild {wild.species.name}", [wild])
+    session = BattleSession(channel, challenger, opponent, "wild")
+    await session.start()
+
+
+async def handle_reaction(message_id: int, emoji: str, user: discord.User) -> Optional[ea_response]:
+    session = ACTIVE_SESSIONS.get(message_id)
+    if not session:
+        return None
+    if emoji in BattleSession.MENU_EMOJIS:
+        return await session.on_menu_action(BattleSession.MENU_EMOJIS[emoji], user)
+    if emoji in BattleSession.NUMBER_EMOJIS:
+        index = BattleSession.NUMBER_EMOJIS.index(emoji)
+        return await session.on_number_selection(index, user)
+    return None
+
+
+async def _menu_callback(payload) -> ea_response:
+    (session, action), user = payload
+    return await session.on_menu_action(action, user)
+
+
+async def _number_callback(payload) -> ea_response:
+    (session, index), user = payload
+    return await session.on_number_selection(index, user)

--- a/data/items/greatball.json
+++ b/data/items/greatball.json
@@ -1,0 +1,6 @@
+{
+  "name": "Great Ball",
+  "price": 25,
+  "catch_rate": 1.5,
+  "description": "A good, high-performance Ball that provides a higher catch rate than a standard Poké Ball."
+}

--- a/data/items/pokeball.json
+++ b/data/items/pokeball.json
@@ -1,0 +1,6 @@
+{
+  "name": "Poké Ball",
+  "price": 10,
+  "catch_rate": 1.0,
+  "description": "A device for catching wild Pokémon. It has a low success rate."
+}

--- a/data/items/potion.json
+++ b/data/items/potion.json
@@ -1,0 +1,6 @@
+{
+  "name": "Potion",
+  "price": 20,
+  "battle_heal": 20,
+  "description": "A spray-type medicine for treating wounds. It restores the HP of one Pokémon by 20 points."
+}

--- a/data/items/superpotion.json
+++ b/data/items/superpotion.json
@@ -1,0 +1,6 @@
+{
+  "name": "Super Potion",
+  "price": 35,
+  "battle_heal": 50,
+  "description": "A spray-type medicine for treating wounds. It restores the HP of one Pokémon by 50 points."
+}

--- a/data/items/ultraball.json
+++ b/data/items/ultraball.json
@@ -1,0 +1,6 @@
+{
+  "name": "Ultra Ball",
+  "price": 50,
+  "catch_rate": 2.0,
+  "description": "An ultra-high performance Ball with a higher success rate for catching Pokémon than a Great Ball."
+}

--- a/data/pokedex.csv
+++ b/data/pokedex.csv
@@ -1,0 +1,37 @@
+index,pokedex_number,name,form,variant,generation,status,pokedex_species,classification,type_1,type_2,height_m,weight_kg,gender_ratio,ability_1,ability_2,ability_hidden,egg_cycles,hp,attack,defense,sp_attack,sp_defense,speed,catch_rate,base_friendship,base_experience,growth_rate
+1,1,Bulbasaur,,,1,Normal,Seed Pokémon,,grass,poison,0.7,6.9,,Overgrow,,Chlorophyll,,45,49,49,65,65,45,45,70,64,medium-slow
+2,2,Ivysaur,,,1,Normal,Seed Pokémon,,grass,poison,1.0,13.0,,Overgrow,,Chlorophyll,,60,62,63,80,80,60,45,70,142,medium-slow
+3,3,Venusaur,,,1,Normal,Seed Pokémon,,grass,poison,2.0,100.0,,Overgrow,,Chlorophyll,,80,82,83,100,100,80,45,70,236,medium-slow
+4,4,Charmander,,,1,Normal,Lizard Pokémon,,fire,,0.6,8.5,,Blaze,,Solar Power,,39,52,43,60,50,65,45,70,62,medium-slow
+5,5,Charmeleon,,,1,Normal,Flame Pokémon,,fire,,1.1,19.0,,Blaze,,Solar Power,,58,64,58,80,65,80,45,70,142,medium-slow
+6,6,Charizard,,,1,Normal,Flame Pokémon,,fire,flying,1.7,90.5,,Blaze,,Solar Power,,78,84,78,109,85,100,45,70,240,medium-slow
+7,7,Squirtle,,,1,Normal,Tiny Turtle Pokémon,,water,,0.5,9.0,,Torrent,,Rain Dish,,44,48,65,50,64,43,45,70,63,medium-slow
+8,8,Wartortle,,,1,Normal,Turtle Pokémon,,water,,1.0,22.5,,Torrent,,Rain Dish,,59,63,80,65,80,58,45,70,142,medium-slow
+9,9,Blastoise,,,1,Normal,Shellfish Pokémon,,water,,1.6,85.5,,Torrent,,Rain Dish,,79,83,100,85,105,78,45,70,239,medium-slow
+10,10,Caterpie,,,1,Normal,Worm Pokémon,,bug,,0.3,2.9,,Shield Dust,,Run Away,,45,30,35,20,20,45,255,70,39,medium-slow
+11,11,Metapod,,,1,Normal,Cocoon Pokémon,,bug,,0.7,9.9,,Shed Skin,,Shed Skin,,50,20,55,25,25,30,120,70,72,medium-slow
+12,12,Butterfree,,,1,Normal,Butterfly Pokémon,,bug,flying,1.1,32.0,,Compound Eyes,,Tinted Lens,,60,45,50,90,80,70,45,70,178,medium-slow
+13,13,Weedle,,,1,Normal,Hairy Bug Pokémon,,bug,poison,0.3,3.2,,Shield Dust,,Run Away,,40,35,30,20,20,50,255,70,39,medium-slow
+14,14,Kakuna,,,1,Normal,Cocoon Pokémon,,bug,poison,0.6,10.0,,Shed Skin,,Shed Skin,,45,25,50,25,25,35,120,70,72,medium-slow
+15,15,Beedrill,,,1,Normal,Poison Bee Pokémon,,bug,poison,1.0,29.5,,Swarm,,Sniper,,65,90,40,45,80,75,45,70,178,medium-slow
+16,16,Pidgey,,,1,Normal,Tiny Bird Pokémon,,normal,flying,0.3,1.8,,Keen Eye,Tangled Feet,Big Pecks,,40,45,40,35,35,56,255,70,50,medium-slow
+17,17,Pidgeotto,,,1,Normal,Bird Pokémon,,normal,flying,1.1,30.0,,Keen Eye,Tangled Feet,Big Pecks,,63,60,55,50,50,71,120,70,122,medium-slow
+18,18,Pidgeot,,,1,Normal,Bird Pokémon,,normal,flying,1.5,39.5,,Keen Eye,Tangled Feet,Big Pecks,,83,80,75,70,70,101,45,70,216,medium-slow
+19,19,Rattata,,,1,Normal,Mouse Pokémon,,normal,,0.3,3.5,,Run Away,Guts,Hustle,,30,56,35,25,35,72,255,70,51,medium-slow
+20,20,Raticate,,,1,Normal,Mouse Pokémon,,normal,,0.7,18.5,,Run Away,Guts,Hustle,,55,81,60,50,70,97,127,70,145,medium-slow
+21,25,Pikachu,,,1,Normal,Mouse Pokémon,,electric,,0.4,6.0,,Static,,Lightning Rod,,35,55,40,50,50,90,190,70,112,medium-fast
+22,26,Raichu,,,1,Normal,Mouse Pokémon,,electric,,0.8,30.0,,Static,,Lightning Rod,,60,90,55,90,80,110,75,70,218,medium-fast
+23,35,Clefairy,,,1,Normal,Fairy Pokémon,,fairy,,0.6,7.5,,Cute Charm,Magic Guard,Friend Guard,,70,45,48,60,65,35,150,70,113,fast
+24,36,Clefable,,,1,Normal,Fairy Pokémon,,fairy,,1.3,40.0,,Cute Charm,Magic Guard,Unaware,,95,70,73,95,90,60,25,70,242,fast
+25,39,Jigglypuff,,,1,Normal,Balloon Pokémon,,normal,fairy,0.5,5.5,,Cute Charm,Competitive,Friend Guard,,115,45,20,45,25,20,170,70,95,fast
+26,40,Wigglytuff,,,1,Normal,Balloon Pokémon,,normal,fairy,1.0,12.0,,Cute Charm,Competitive,Frisk,,140,70,45,85,50,45,50,70,218,fast
+27,52,Meowth,,,1,Normal,Scratch Cat Pokémon,,normal,,0.4,4.2,,Pickup,Technician,Unnerve,,40,45,35,40,40,90,255,70,58,medium-fast
+28,53,Persian,,,1,Normal,Classy Cat Pokémon,,normal,,1.0,32.0,,Limber,Technician,Unnerve,,65,70,60,65,65,115,90,70,154,medium-fast
+29,58,Growlithe,,,1,Normal,Puppy Pokémon,,fire,,0.7,19.0,,Intimidate,Flash Fire,Justified,,55,70,45,70,50,60,190,70,70,slow
+30,59,Arcanine,,,1,Normal,Legendary Pokémon,,fire,,1.9,155.0,,Intimidate,Flash Fire,Justified,,90,110,80,100,80,95,75,70,194,slow
+31,63,Abra,,,1,Normal,Psi Pokémon,,psychic,,0.9,19.5,,Synchronize,Inner Focus,Magic Guard,,25,20,15,105,55,90,200,70,62,medium-slow
+32,64,Kadabra,,,1,Normal,Psi Pokémon,,psychic,,1.3,56.5,,Synchronize,Inner Focus,Magic Guard,,40,35,30,120,70,105,100,70,140,medium-slow
+33,65,Alakazam,,,1,Normal,Psi Pokémon,,psychic,,1.5,48.0,,Synchronize,Inner Focus,Magic Guard,,55,50,45,135,95,120,50,70,225,medium-slow
+34,66,Machop,,,1,Normal,Superpower Pokémon,,fighting,,0.8,19.5,,Guts,No Guard,Steadfast,,70,80,50,35,35,35,180,70,61,medium-slow
+35,67,Machoke,,,1,Normal,Superpower Pokémon,,fighting,,1.5,70.5,,Guts,No Guard,Steadfast,,80,100,70,50,60,45,90,70,142,medium-slow
+36,68,Machamp,,,1,Normal,Superpower Pokémon,,fighting,,1.6,130.0,,Guts,No Guard,Steadfast,,90,130,80,65,85,55,45,70,227,medium-slow

--- a/economy.py
+++ b/economy.py
@@ -28,8 +28,10 @@ async def buy(message, item_key):
         return
     # Perform Transaction
     user_gain_item(uid, item_key)
-    user["bp"] -=item["price"]
+    user = USERS[uid]
+    user["bp"] -= item["price"]
     USERS[uid] = user
+    USERS.save_item(uid)
     await message.reply(f"Here's your {item_name}! We hope to see you again!")
         
     
@@ -57,8 +59,9 @@ def user_gain_item(uid, item_key, qty=1):
         user["items"][item_key] = qty
     else:
         user["items"][item_key] += qty
-    
+
     USERS[uid] = user
+    USERS.save_item(uid)
 
 def user_spend_item(uid, item_key, qty=1):
     """
@@ -71,7 +74,7 @@ def user_spend_item(uid, item_key, qty=1):
     """
     if uid not in USERS:
         print(f"{tc.R}Cannot grant item {tc.W}\"{item_key}\"{tc.R} to user because there is no user with this uid:\n{tc.B}{uid}{tc.W}")
-        return
+        return False
     if qty < 0:
         print(f"{tc.O}Warning: tried to give {qty} {tc.W}\"{item_key}\"{tc.O} to user {tc.B}{uid}{tc.O}\nQuantity converted to positive.{tc.W}")
         qty = -qty
@@ -82,4 +85,5 @@ def user_spend_item(uid, item_key, qty=1):
         return False
     user["items"][item_key] -= qty
     USERS[uid] = user
+    USERS.save_item(uid)
     return True

--- a/embeds.py
+++ b/embeds.py
@@ -1,9 +1,15 @@
 import discord
+
 from discobot_modules.graphics import moon_bar
 from db import USERS
 from db import ITEMS
 import classes
 from economy import user_item_count
+from pathlib import Path
+from typing import Iterable, List, Sequence, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from battle import BattleParticipant, BattleResult
 
 """
 This module defines all the embeds that the bot can display.
@@ -11,19 +17,32 @@ This module defines all the embeds that the bot can display.
 An embed is a panel with information arranged hierarchically.
 """
 
+STAT_ORDER = classes.STAT_KEYS
+STAT_LABELS = {
+    "hp": "HP",
+    "attack": "Attack",
+    "defense": "Defense",
+    "sp_attack": "Sp. Atk",
+    "sp_defense": "Sp. Def",
+    "speed": "Speed",
+}
+
 ############################
 # Help Embeds
 ############################
 
 def help():
     desc = "To get started, ping the bot!"
-    em = discord.Embed(title="Mew Pokébot 0.1.1", description=desc, color=0xA0A1B0)
+    em = discord.Embed(title="Mew Pokébot 0.2.0", description=desc, color=0xA0A1B0)
     em.set_thumbnail(url="https://i.pinimg.com/originals/05/51/f5/0551f506725ac1deeaa85d46f8b9a5fd.jpg")
     em.add_field(name="Earn Battle Points", value="Chatting in the server can earn you BP!")
     em.add_field(name="Find Wild Pokemon", value="Occasionally, wild pokemon will spawn. Will you be the one to catch it?")
     em.add_field(name="!shop", value="Show the shop screen, so you can buy items.", inline=False)
     em.add_field(name="!pokedex", value="View the pokedex. Type !pokedex 151 to see a specific pokemon.")
     em.add_field(name="!summary", value="Take a look at your own pokemon. type a number to see a specific one of your mons.")
+    em.add_field(name="!party", value="Review and edit your battling party. Try `!party add 3` to add a caught Pokémon.", inline=False)
+    em.add_field(name="!train", value="Spend BP to boost your party's stats, e.g. `!train 1 attack`.", inline=False)
+    em.add_field(name="!battle", value="Challenge another trainer with your party using `!battle @trainer` and pick moves with the reaction controls.")
     em.add_field(name="!dev", value="Check out the bot creator and read Mew's source code!")
     #em.add_field(name="!leaderboard", value="Display the leaderboard of today's top players.")
     return em
@@ -66,47 +85,118 @@ def plug():
 # Profile Embeds
 ############################
 
+def _battle_value(entry) -> float:
+    if isinstance(entry, dict):
+        outcome = entry.get("outcome")
+        if outcome == "win":
+            return 1.0
+        if outcome == "draw":
+            return 0.5
+        return 0.0
+    if isinstance(entry, (list, tuple)) and entry:
+        try:
+            return float(entry[0])
+        except (TypeError, ValueError):
+            return 0.0
+    return 0.0
+
+
 def user_wincount(user):
     total = 0
-    for battle in user["battles"]:
-        if battle[0] == 1:
-            total += 1
+    for battle in user.get("battles", []):
+        if isinstance(battle, dict):
+            if battle.get("outcome") == "win":
+                total += 1
+        elif isinstance(battle, (list, tuple)) and battle:
+            if battle[0] == 1:
+                total += 1
     return total
 
+
 def user_winlossratio(user):
-    if len(user["battles"]) == 0:
-        return 0 # Divide by zero error protection
+    battles = user.get("battles", [])
+    if not battles:
+        return 0
     total = 0
-    for battle in user["battles"]:
-        total += battle[0]
-    return total / len(user["battles"])
+    for battle in battles:
+        total += _battle_value(battle)
+    return total / len(battles)
 
 def profile(user):
-    
+
     udic = USERS[user.id]
-    bp = udic["bp"]
+    bp = udic.get("bp", 0)
     wins = user_wincount(udic)
     wlr = user_winlossratio(udic)
-    #chars = udic["chars"]
-    desc = f":coin:{bp}\n:trophy:{wins}\n:lifter:{wlr}"
-    em = discord.Embed(title=user.name, description=desc, color=0xA0A1B0)
-    em.set_thumbnail(url=user.display_avatar.url)
-    pkmn = ""
-    for i, mon in enumerate(USERS[user.id]["pokemon"]):
-        mymon = classes.Individual.from_dict(mon)
-        pkmn += mymon.get_name()
-        pkmn += "\n"
-        if i > 5:
-            break
-    pkmn = pkmn if pkmn else "None."
-    pkcount = len(USERS[user.id]["pokemon"])
-    
-    em.add_field(name=f"Caught Pokemon: {pkcount}", value="Items:", inline=False)
-    em.add_field(name="<:poke:1092956340349046844> Pokeball", value=str(user_item_count(user.id,"pokeball")))
-    em.add_field(name="<:great:1092956339166248961> Greatball", value=str(user_item_count(user.id,"greatball")))
-    em.add_field(name="<:ultra:1092956341670252624> Ultraball", value=str(user_item_count(user.id,"ultraball")))
+    desc = f":coin:{bp}\n:trophy:{wins}\n:lifter:{wlr:.2f}"
+    title = getattr(user, "display_name", None) or getattr(user, "name", "Trainer")
+    em = discord.Embed(title=title, description=desc, color=0xA0A1B0)
+    if getattr(user, "display_avatar", None):
+        em.set_thumbnail(url=user.display_avatar.url)
 
-    em.add_field(name="Pokemon:", value=pkmn, inline=False)
+    roster_map = {}
+    collection = []
+    for index, mon_data in enumerate(udic.get("pokemon", []), start=1):
+        mon = classes.Individual.from_dict(mon_data)
+        if not mon:
+            continue
+        roster_map[mon_data.get("uid")] = mon
+        if len(collection) < 10:
+            shiny = " ✨" if mon.shiny else ""
+            collection.append(f"{index}. {mon.get_title()}{shiny}")
+
+    party_lines = []
+    for idx, mon_id in enumerate(udic.get("party", []), start=1):
+        mon = roster_map.get(mon_id)
+        if not mon:
+            continue
+        shiny = " ✨" if mon.shiny else ""
+        party_lines.append(f"{idx}. {mon.get_title()} Lv{mon.level}{shiny}")
+    party_text = "\n".join(party_lines) if party_lines else "Set your party with `!party add <number>`."
+
+    em.add_field(name="Party", value=party_text, inline=False)
+
+    pkcount = len(roster_map)
+    collection_text = "\n".join(collection) if collection else "None yet."
+    em.add_field(name=f"Caught Pokémon: {pkcount}", value=collection_text, inline=False)
+
+    em.add_field(name="Items", value="—", inline=False)
+    em.add_field(name="<:poke:1092956340349046844> Pokeball", value=str(user_item_count(user.id, "pokeball")))
+    em.add_field(name="<:great:1092956339166248961> Greatball", value=str(user_item_count(user.id, "greatball")))
+    em.add_field(name="<:ultra:1092956341670252624> Ultraball", value=str(user_item_count(user.id, "ultraball")))
+
+    return em
+
+
+def party(user, party_members: Sequence[classes.Individual], roster_members: Sequence[classes.Individual], note: str = ""):
+    title = getattr(user, "display_name", None) or getattr(user, "name", "Trainer")
+    description = note or "Use `!party add <number>` to add Pokémon from your collection."
+    em = discord.Embed(title=f"{title}'s Party", description=description, color=0x5B6EE1)
+
+    if getattr(user, "display_avatar", None):
+        em.set_thumbnail(url=user.display_avatar.url)
+
+    if party_members:
+        lines = []
+        for idx, mon in enumerate(party_members, start=1):
+            shiny = " ✨" if mon.shiny else ""
+            lines.append(f"{idx}. {mon.get_title()} Lv{mon.level}{shiny}")
+        em.add_field(name="Active Party", value="\n".join(lines), inline=False)
+    else:
+        em.add_field(name="Active Party", value="No Pokémon selected. Try `!party add 1`.", inline=False)
+
+    if roster_members:
+        lines = []
+        for idx, mon in enumerate(roster_members, start=1):
+            shiny = " ✨" if mon.shiny else ""
+            lines.append(f"{idx}. {mon.get_title()} Lv{mon.level}{shiny}")
+            if idx == 20:
+                lines.append("…")
+                break
+        em.add_field(name="Collection", value="\n".join(lines), inline=False)
+    else:
+        em.add_field(name="Collection", value="You haven't caught any Pokémon yet.", inline=False)
+
     return em
 
 
@@ -115,7 +205,6 @@ def profile(user):
 ############################
 
 def stat_blocks(pokemon):
-    # define helpful lists
     colors = [
         "⬛",
         "🟥",
@@ -124,31 +213,29 @@ def stat_blocks(pokemon):
         "🟩",
         "🟦",
     ]
-    stats = pokemon.get_stats_list()
-    names = [
-        "HP",
-        "ATK",
-        "DEF",
-        "SPATK",
-        "SPDEF",
-        "SPEED"
-    ]
-    # Original stats
-    values = stats.copy()
-    # Round stats by dividing by 50
-    stats = [int(round(x/50)) for x in stats]
-    # Add a line to the string for each stat.
-    text = ""
-    for stat, name, value in zip(stats, names, values):
-        text += name + " "
-        # add a certain amount of blocks.
-        # Add 1 if the value is rounded to 0.
-        blocks = max(stat,1)
-        for i in range(blocks):
-            text += colors[stat]
-        #text += str(value)
-        text += "\n"
-    return text
+    if isinstance(pokemon, classes.Individual):
+        stat_map = pokemon.get_stats()
+    else:
+        stat_map = dict(zip(STAT_ORDER, pokemon.get_stats_list()))
+
+    labels = {
+        "hp": "HP",
+        "attack": "ATK",
+        "defense": "DEF",
+        "sp_attack": "SPATK",
+        "sp_defense": "SPDEF",
+        "speed": "SPEED",
+    }
+
+    text_lines: List[str] = []
+    for key in STAT_ORDER:
+        value = stat_map.get(key, 0)
+        scaled = int(round(value / 50))
+        blocks = max(scaled, 1)
+        color_index = min(scaled, len(colors) - 1)
+        line = labels[key] + " " + colors[color_index] * blocks + f" ({int(value)})"
+        text_lines.append(line)
+    return "\n".join(text_lines)
     
 
 def pokedex(pokemon_id):
@@ -181,6 +268,18 @@ def pokemon_summary(pokemon_instance):
     desc += f"\n{poketypes}\n{pokestats}"
     em = discord.Embed(title=title, description=desc, color=0xE12005)
     em.set_image(url=pokemon_instance.species.naive_image())
+    if isinstance(pokemon_instance, classes.Individual):
+        iv_parts = [f"{STAT_LABELS[key]} {pokemon_instance.ivs[key]}" for key in STAT_ORDER]
+        ev_total = pokemon_instance.total_evs()
+        ev_parts = [
+            f"{STAT_LABELS[key]} {pokemon_instance.evs[key]}"
+            for key in STAT_ORDER
+            if pokemon_instance.evs.get(key, 0) > 0
+        ]
+        iv_text = " | ".join(iv_parts)
+        ev_text = " | ".join(ev_parts) if ev_parts else "No EV training yet."
+        em.add_field(name="IVs", value=iv_text, inline=False)
+        em.add_field(name=f"EVs {ev_total}/510", value=ev_text, inline=False)
     return em
     
 
@@ -193,12 +292,36 @@ def shop():
     desc = "More items coming soon!"
     em = discord.Embed(title="POKEBOT SHOP", description=desc, color=0xA0A1B0)
     em.set_thumbnail(url="https://i.pinimg.com/originals/05/51/f5/0551f506725ac1deeaa85d46f8b9a5fd.jpg")
-    price = ITEMS["pokeball"]["price"]
-    em.add_field(name="<:poke:1092956340349046844> Pokeball BP5", value="Normal catch rate.\n!buy pokeball")
-    price = ITEMS["greatball"]["price"]
-    em.add_field(name="<:great:1092956339166248961> Greatball BP10", value="1.5x catch rate.\n!buy greatball")
-    price = ITEMS["ultraball"]["price"]
-    em.add_field(name="<:ultra:1092956341670252624> Ultraball BP15", value="2x catch rate.\n!buy ultraball")
+    pb_price = ITEMS["pokeball"]["price"]
+    em.add_field(
+        name=f"<:poke:1092956340349046844> Poké Ball — {pb_price} BP",
+        value="A basic ball with a standard catch rate.\n`!buy pokeball`",
+        inline=False,
+    )
+    gb_price = ITEMS["greatball"]["price"]
+    em.add_field(
+        name=f"<:great:1092956339166248961> Great Ball — {gb_price} BP",
+        value="Higher chance to catch than a Poké Ball.\n`!buy greatball`",
+        inline=False,
+    )
+    ub_price = ITEMS["ultraball"]["price"]
+    em.add_field(
+        name=f"<:ultra:1092956341670252624> Ultra Ball — {ub_price} BP",
+        value="Premium catch rate for tough encounters.\n`!buy ultraball`",
+        inline=False,
+    )
+    potion_price = ITEMS["potion"]["price"]
+    em.add_field(
+        name=f"🧴 Potion — {potion_price} BP",
+        value="Heals 20 HP mid-battle.\n`!buy potion`",
+        inline=False,
+    )
+    super_price = ITEMS["superpotion"]["price"]
+    em.add_field(
+        name=f"🧴 Super Potion — {super_price} BP",
+        value="Heals 50 HP mid-battle.\n`!buy superpotion`",
+        inline=False,
+    )
     return em
 
 
@@ -211,63 +334,170 @@ def wild_encounter(pkmn):
     if pkmn.shiny:
         status = "SHINY"
     title= f"WILD {status} ENCOUNTER"
-    pokestats = stat_blocks(pkmn)
-    desc = f"**A wild {pkmn.species.name} appeared!**"
+    desc = f"**A wild {pkmn.species.name} appeared!**\nLevel {pkmn.level}"
     em = discord.Embed(title=title, description=desc, color=0xE12005)
     em.set_image(url=pkmn.species.naive_image())
     return em
-    
-def battle(battle):
-    # Not yet implemented.
-    ...
+
+def _format_party_block(participant: "BattleParticipant") -> str:
+    if not participant.party:
+        return "—"
+    lines: List[str] = []
+    for idx, mon in enumerate(participant.party, start=1):
+        shiny = " ✨" if mon.shiny else ""
+        lines.append(f"{idx}. {mon.get_title()} Lv{mon.level}{shiny}")
+        if len("\n".join(lines)) > 950:
+            lines.append("…")
+            break
+    return "\n".join(lines)
+
+
+def _chunk_log(lines: Iterable[str], limit: int = 1024) -> List[List[str]]:
+    chunks: List[List[str]] = []
+    current: List[str] = []
+    current_len = 0
+    for line in lines:
+        addition = len(line) + 1
+        if current and current_len + addition > limit:
+            chunks.append(current)
+            current = []
+            current_len = 0
+        current.append(line)
+        current_len += addition
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def battle(result: "BattleResult"):
+    challenger, opponent = result.participants
+    if result.winner is None:
+        outcome = "It's a draw!"
+    else:
+        winner = result.participants[result.winner]
+        outcome = f"{winner.name} wins the battle!"
+    battle_type = "Trainer Battle" if result.battle_type == "trainer" else "Wild Encounter"
+    color = 0x3B82F6 if result.battle_type == "trainer" else 0xE12005
+    desc = f"{challenger.name} vs {opponent.name}\n{outcome}\nType: {battle_type}"
+    em = discord.Embed(title="Battle Results", description=desc, color=color)
+
+    log_lines = result.log or ["No events were recorded."]
+    for idx, chunk in enumerate(_chunk_log(log_lines), start=1):
+        em.add_field(name=f"Log {idx}", value="\n".join(chunk), inline=False)
+
+    em.add_field(name=f"{challenger.name}'s Party", value=_format_party_block(challenger), inline=True)
+    em.add_field(name=f"{opponent.name}'s Party", value=_format_party_block(opponent), inline=True)
+
+    if result.rewards:
+        rewards_text = []
+        for uid, delta in result.rewards.items():
+            if delta == 0:
+                continue
+            if uid == challenger.user_id:
+                name = challenger.name
+            elif uid == opponent.user_id:
+                name = opponent.name
+            else:
+                name = f"Trainer {uid}"
+            sign = "+" if delta >= 0 else ""
+            rewards_text.append(f"{name}: {sign}{delta} BP")
+        if rewards_text:
+            em.add_field(name="Rewards", value="\n".join(rewards_text), inline=False)
+
+    if getattr(result, "experience_log", None):
+        lines = []
+        for uid, events in result.experience_log.items():
+            name = challenger.name if uid == challenger.user_id else opponent.name if uid == opponent.user_id else f"Trainer {uid}"
+            for event in events:
+                lines.append(f"{name}: {event}")
+        if lines:
+            em.add_field(name="Experience", value="\n".join(lines[:10]), inline=False)
+
+    em.set_footer(text=f"Rounds fought: {result.rounds}")
+    return em
 
 ############################
 # Leaderboard Embeds
 ############################
 
 
-def leaderboard(title, desc, sortingfunc, key, emoji, length=10, color=0x606170):
+def _all_users():
+    users = []
+    seen = set()
+    # Include any users already cached in memory.
+    for uid, data in USERS.cache.items():
+        users.append((uid, data))
+        seen.add(uid)
+
+    # Load any remaining users from disk.
+    directory = Path(USERS.path_prefix)
+    if directory.exists():
+        for file in directory.glob("*.json"):
+            key = file.stem
+            try:
+                key = int(key)
+            except ValueError:
+                pass
+            if key in seen:
+                continue
+            try:
+                users.append((key, USERS[key]))
+            except FileNotFoundError:
+                continue
+    return users
+
+
+def leaderboard(title, desc, sortingfunc, value_func, emoji, length=10, color=0x606170):
     # Sort leaderboard by specific topic
-    sorted_udex = sorted(USERS.cache.items(), key=sortingfuc, reverse=True)
-    
+    sorted_udex = sorted(_all_users(), key=sortingfunc, reverse=True)
+
     # Create embed
     em = discord.Embed(title=title, description=desc, color=color, url="")
 
     for uid, user in sorted_udex:
-        em.add_field(name=user["name"], value=emoji+str(user[key]), inline=False)
+        display_name = user.get("name", f"User {uid}")
+        value = value_func(uid, user)
+        em.add_field(name=display_name, value=f"{emoji} {value}", inline=False)
         if len(em.fields) == length:
             break
+
+    if len(em.fields) == 0:
+        em.add_field(name="No trainers found", value="Start chatting to appear on the leaderboard!", inline=False)
     return em
 
 
 def leaderboard_bp():
     return leaderboard(
-                    "RICHEST PLAYERS", 
+                    "RICHEST PLAYERS",
                     "Some of the most active users today...",
-                    lambda x: x[1]["bp"],
+                    lambda x: x[1].get("bp", 0),
+                    lambda _uid, user: user.get("bp", 0),
                     ":coin:"
                     )
 
 def leaderboard_most_mons():
     return leaderboard(
-                    "POKEMON COLLECTORS", 
+                    "POKEMON COLLECTORS",
                     "Some of the most active users today...",
-                    lambda x: len(x[1]["pokemon"]),
+                    lambda x: len(x[1].get("pokemon", [])),
+                    lambda _uid, user: len(user.get("pokemon", [])),
                     "<:poke:1092956340349046844>"
                     )
-                    
+
 def leaderboard_wins():
     return leaderboard(
-                    "BIGGEST FIGHTERS", 
+                    "BIGGEST FIGHTERS",
                     "Some of the most active users today...",
                     lambda x: user_wincount(x[1]),
+                    lambda _uid, user: user_wincount(user),
                     ":trophy:"
                     )
 
 def leaderboard_wlr():
     return leaderboard(
-                    "EXPERT BATTLERS", 
+                    "EXPERT BATTLERS",
                     "Some of the most active users today...",
                     lambda x: user_winlossratio(x[1]),
+                    lambda _uid, user: f"{user_winlossratio(user):.2f}",
                     ":lifter:"
                     )

--- a/evolutions.py
+++ b/evolutions.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple
+
+
+LEVEL_EVOLUTIONS: Dict[int, Tuple[int, int]] = {
+    1: (16, 2),
+    2: (32, 3),
+    4: (16, 5),
+    5: (36, 6),
+    7: (16, 8),
+    8: (36, 9),
+    10: (7, 11),
+    11: (10, 12),
+    13: (7, 14),
+    14: (10, 15),
+    16: (18, 17),
+    17: (36, 18),
+    19: (20, 20),
+    25: (30, 26),
+    35: (35, 36),
+    39: (30, 40),
+    52: (28, 53),
+    58: (35, 59),
+    63: (16, 64),
+    64: (36, 65),
+    66: (28, 67),
+    67: (40, 68),
+}
+
+
+def next_evolution(species_id: int, level: int) -> Optional[int]:
+    entry = LEVEL_EVOLUTIONS.get(int(species_id))
+    if not entry:
+        return None
+    required_level, evolved_species = entry
+    if level >= required_level:
+        return evolved_species
+    return None

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ import users
 import db
 import encounters
 import economy
+import battle
 
 
 
@@ -54,52 +55,146 @@ async def on_message(message):
 
     msg = message.content
     msgl = msg.lower()
-    
+
     if msgl == "": # Handle image-only messages
         msgl = "."
-    
-    if msgl.split()[0] == "!hello":
+
+    parts = msgl.split()
+    command = parts[0]
+    args = parts[1:]
+
+    author_id = message.author.id
+    award_chat_bp = True
+    if author_id not in db.USERS:
+        users.new_user(message.author)
+    users.ensure_user_record(author_id)
+    users.update_display_name(message.author)
+
+    if command == "!hello":
         await message.channel.send("hi :)")
-        
-    if msgl.split()[0] == "!help":
+
+    if command == "!help":
         await message.reply(embed = embeds.help())
-    
-    if msgl.split()[0] in ["!dev", "!github", "!source", "!comms", "!plug", "!shamelessplug", "!butte", "!gay"]:
+
+    if command in ["!dev", "!github", "!source", "!comms", "!plug", "!shamelessplug", "!butte", "!gay"]:
         await message.reply(embed = embeds.plug())
-    
-    
+
+
     #ping the bot
-    if msgl.split()[0] == client.user.mention:
+    if command == client.user.mention:
         await users.profile(message)
 
-    if msgl.split()[0] == "!roll":
+    if command == "!roll":
         await dice.roll(message)
 
-    if msgl.split()[0] == "!egg":
+    if command == "!egg":
         await egg.egg_timer(message)
-    
-    if msgl.split()[0] == "!shop":
+
+    if command == "!shop":
         await economy.send_shop_screen(message)
-        
-    if msgl.split()[0] == "!buy":
-        if msgl.split()[1] in ["pokeball", "greatball", "ultraball"]:
-            await economy.buy(message, msgl.split()[1])
-            
-    if msgl.split()[0] == "!pokedex":
-        await message.reply(embed = embeds.pokedex(int(msgl.split()[1])))
-        
-    if msgl.split()[0] == "!summary":
-        index = 0
-        if msgl.split()[1].isdigit():
-            index = int(msgl.split()[1])
-        pkmn = classes.Individual.from_dict(db.USERS[message.author.id]["pokemon"][index])
-        await message.reply(embed = embeds.pokemon_summary(pkmn))
-    
+
+    if command == "!buy":
+        if not args:
+            await message.reply("What would you like to buy? Try `!buy pokeball`.")
+        else:
+            item_key = args[0].lower()
+            if item_key in ["pokeball", "greatball", "ultraball", "potion", "superpotion"]:
+                await economy.buy(message, item_key)
+            else:
+                await message.reply("That item isn't in stock right now.")
+
+    if command == "!pokedex":
+        if not args:
+            await message.reply("Please specify a Pokédex number, e.g. `!pokedex 151`.")
+        else:
+            try:
+                await message.reply(embed = embeds.pokedex(int(args[0])))
+            except ValueError:
+                await message.reply("I couldn't understand that Pokédex number.")
+
+    if command == "!summary":
+        index = 1
+        if args and args[0].isdigit():
+            index = int(args[0])
+        if index <= 0:
+            await message.reply("Pokémon numbers start at 1.")
+            return
+        try:
+            user = db.USERS[author_id]
+            pokemon_list = user["pokemon"]
+            if not pokemon_list:
+                await message.reply("You haven't caught any Pokémon yet!")
+                return
+            if index > len(pokemon_list):
+                await message.reply("You don't have that many Pokémon yet.")
+                return
+            pkmn = classes.Individual.from_dict(pokemon_list[index - 1])
+            if not pkmn:
+                raise ValueError
+        except (KeyError, IndexError, ValueError):
+            await message.reply("I couldn't find that Pokémon in your collection.")
+            return
+        await message.reply(embed=embeds.pokemon_summary(pkmn))
+
+    if command == "!party":
+        await users.party_command(message, args)
+
+    if command == "!train":
+        await users.train_command(message, args)
+
+    if command == "!leaderboard":
+        board_key = args[0] if args else "bp"
+        boards = {
+            "bp": embeds.leaderboard_bp,
+            "mons": embeds.leaderboard_most_mons,
+            "pokemon": embeds.leaderboard_most_mons,
+            "wins": embeds.leaderboard_wins,
+            "wlr": embeds.leaderboard_wlr,
+        }
+        board_func = boards.get(board_key)
+        if board_func:
+            await message.reply(embed = board_func())
+        else:
+            await message.reply("Unknown leaderboard. Try `bp`, `mons`, `wins`, or `wlr`.")
+
+    if command == "!battle":
+        award_chat_bp = False
+        if not message.mentions:
+            await message.reply("You need to mention a trainer to battle, e.g. `!battle @Mew`.")
+        else:
+            opponent = message.mentions[0]
+            if opponent.id == author_id:
+                await message.reply("You can't battle yourself!")
+            elif opponent.bot:
+                await message.reply("Battling bots isn't supported yet.")
+            else:
+                if opponent.id not in db.USERS:
+                    users.new_user(opponent)
+                users.ensure_user_record(opponent.id)
+                users.update_display_name(opponent)
+                challenger_party = users.get_party_members(author_id)
+                if not challenger_party:
+                    await message.reply("Set up a party with `!party add <number>` before battling!")
+                else:
+                    opponent_party = users.get_party_members(opponent.id)
+                    if not opponent_party:
+                        await message.reply(f"{opponent.mention} doesn't have a party ready yet.")
+                    else:
+                        await battle.start_trainer_battle(
+                            message,
+                            author_id,
+                            getattr(message.author, "display_name", message.author.name),
+                            challenger_party,
+                            opponent.id,
+                            getattr(opponent, "display_name", opponent.name),
+                            opponent_party,
+                        )
+
     # Award bp to chatters.
-    if message.author.id in db.USERS:
+    if award_chat_bp:
         frequency = 1.0
         if random.random() <= frequency:
-            db.USERS[message.author.id]["bp"] += 1
+            users.adjust_bp(author_id, 1)
     
     # Random Spawns
     SPAWN_RATE = 0.02
@@ -116,21 +211,19 @@ async def on_message(message):
         print("__--~~ADMIN SPEAKING~~--__")
         if msgl == "!admin help":
             await message.reply(embed = embeds.help())
-        if msgl.split()[0] == "!save":
+        if command == "!save":
             db.save_db()
             await message.channel.send("Saved database.")
-        if msgl.split()[0] in ["]", "die", "kill"]:
+        if command in ["]", "die", "kill"]:
             await message.channel.send("Saving database and killing bot process...")
             db.save_db()
             quit()
-        if msgl.split()[0] == "!makpkmn":
-            
-            spec = classes.Species.load_index(int(msgl.split()[1]))
-            
-            newmon = classes.Individual(spec, nickname=msgl.split()[2])
-            
+        if command == "!makpkmn" and len(args) >= 2:
+            spec = classes.Species.load_index(int(args[0]))
+            newmon = classes.Individual(spec, nickname=args[1])
             db.USERS[message.author.id]["pokemon"].append(newmon.to_dict())
-        if msgl.split()[0] == "!spawn":
+            db.USERS.save_item(message.author.id)
+        if command == "!spawn":
             await encounters.roll_possible_encounter(message.channel, 1)
     
     # memes

--- a/moves.py
+++ b/moves.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+
+@dataclass(frozen=True)
+class Move:
+    """Represents a move a Pokémon can use in battle."""
+
+    key: str
+    name: str
+    type: str
+    category: str  # physical, special, or status
+    power: int = 0
+    accuracy: float = 1.0
+    priority: int = 0
+    status: Optional[str] = None
+    status_chance: float = 0.0
+    heal: int = 0
+    description: str = ""
+
+
+MOVES: Dict[str, Move] = {
+    "tackle": Move("tackle", "Tackle", "normal", "physical", power=40, accuracy=0.95),
+    "quick_attack": Move("quick_attack", "Quick Attack", "normal", "physical", power=40, accuracy=1.0, priority=1),
+    "vine_whip": Move("vine_whip", "Vine Whip", "grass", "physical", power=45, accuracy=1.0),
+    "razor_leaf": Move("razor_leaf", "Razor Leaf", "grass", "physical", power=55, accuracy=0.95),
+    "sleep_powder": Move("sleep_powder", "Sleep Powder", "grass", "status", power=0, accuracy=0.75, status="sleep", status_chance=1.0),
+    "ember": Move("ember", "Ember", "fire", "special", power=40, accuracy=1.0, status="burn", status_chance=0.1),
+    "flame_wheel": Move("flame_wheel", "Flame Wheel", "fire", "physical", power=60, accuracy=1.0, status="burn", status_chance=0.1),
+    "will_o_wisp": Move("will_o_wisp", "Will-O-Wisp", "fire", "status", power=0, accuracy=0.85, status="burn", status_chance=1.0),
+    "water_gun": Move("water_gun", "Water Gun", "water", "special", power=40, accuracy=1.0),
+    "bubble_beam": Move("bubble_beam", "Bubble Beam", "water", "special", power=65, accuracy=1.0),
+    "aqua_tail": Move("aqua_tail", "Aqua Tail", "water", "physical", power=90, accuracy=0.9),
+    "thunder_shock": Move("thunder_shock", "Thunder Shock", "electric", "special", power=40, accuracy=1.0, status="paralysis", status_chance=0.1),
+    "spark": Move("spark", "Spark", "electric", "physical", power=65, accuracy=1.0, status="paralysis", status_chance=0.3),
+    "thunder_wave": Move("thunder_wave", "Thunder Wave", "electric", "status", accuracy=0.9, status="paralysis", status_chance=1.0),
+    "gust": Move("gust", "Gust", "flying", "special", power=40, accuracy=1.0),
+    "air_slash": Move("air_slash", "Air Slash", "flying", "special", power=75, accuracy=0.95),
+    "confusion": Move("confusion", "Confusion", "psychic", "special", power=50, accuracy=1.0),
+    "psybeam": Move("psybeam", "Psybeam", "psychic", "special", power=65, accuracy=1.0),
+    "future_sight": Move("future_sight", "Future Sight", "psychic", "special", power=120, accuracy=1.0),
+    "karate_chop": Move("karate_chop", "Karate Chop", "fighting", "physical", power=50, accuracy=1.0),
+    "low_sweep": Move("low_sweep", "Low Sweep", "fighting", "physical", power=65, accuracy=1.0),
+    "vital_throw": Move("vital_throw", "Vital Throw", "fighting", "physical", power=70, accuracy=1.0, priority=-1),
+    "scratch": Move("scratch", "Scratch", "normal", "physical", power=40, accuracy=1.0),
+    "bite": Move("bite", "Bite", "dark", "physical", power=60, accuracy=1.0),
+    "slam": Move("slam", "Slam", "normal", "physical", power=80, accuracy=0.75),
+    "dragon_rage": Move("dragon_rage", "Dragon Rage", "dragon", "special", power=40, accuracy=1.0),
+    "disarming_voice": Move("disarming_voice", "Disarming Voice", "fairy", "special", power=40, accuracy=1.0),
+    "dazzling_gleam": Move("dazzling_gleam", "Dazzling Gleam", "fairy", "special", power=80, accuracy=1.0),
+    "moonblast": Move("moonblast", "Moonblast", "fairy", "special", power=95, accuracy=1.0),
+    "poison_sting": Move("poison_sting", "Poison Sting", "poison", "physical", power=30, accuracy=1.0, status="poison", status_chance=0.3),
+    "sludge_bomb": Move("sludge_bomb", "Sludge Bomb", "poison", "special", power=90, accuracy=1.0, status="poison", status_chance=0.3),
+    "bug_bite": Move("bug_bite", "Bug Bite", "bug", "physical", power=60, accuracy=1.0),
+    "signal_beam": Move("signal_beam", "Signal Beam", "bug", "special", power=75, accuracy=1.0),
+}
+
+
+TYPE_SIGNATURE_MOVES: Dict[str, List[str]] = {
+    "grass": ["tackle", "vine_whip", "razor_leaf", "sleep_powder"],
+    "fire": ["scratch", "ember", "flame_wheel", "will_o_wisp"],
+    "water": ["tackle", "water_gun", "bubble_beam", "aqua_tail"],
+    "electric": ["quick_attack", "thunder_shock", "spark", "thunder_wave"],
+    "normal": ["tackle", "quick_attack", "bite", "slam"],
+    "flying": ["tackle", "gust", "quick_attack", "air_slash"],
+    "poison": ["poison_sting", "tackle", "sludge_bomb"],
+    "bug": ["tackle", "bug_bite", "signal_beam"],
+    "psychic": ["confusion", "psybeam", "future_sight"],
+    "fighting": ["karate_chop", "low_sweep", "vital_throw"],
+    "fairy": ["disarming_voice", "dazzling_gleam", "moonblast"],
+    "dragon": ["dragon_rage", "slam"],
+    "dark": ["bite", "slam"],
+}
+
+
+def get(key: str) -> Optional[Move]:
+    return MOVES.get(key)
+
+
+def as_list(keys: Iterable[str]) -> List[Move]:
+    return [move for key in keys if (move := MOVES.get(key))]

--- a/users.py
+++ b/users.py
@@ -1,9 +1,399 @@
+from __future__ import annotations
+
+import math
+import time
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import classes
 from db import USERS
 import embeds
 
-"""
-This module handles user profiles and the onboarding system.
-"""
+STAT_DISPLAY = {
+    "hp": "HP",
+    "attack": "Attack",
+    "defense": "Defense",
+    "sp_attack": "Sp. Atk",
+    "sp_defense": "Sp. Def",
+    "speed": "Speed",
+}
+
+STAT_ALIASES = {
+    "hp": "hp",
+    "health": "hp",
+    "atk": "attack",
+    "attack": "attack",
+    "def": "defense",
+    "defense": "defense",
+    "spd": "speed",
+    "spe": "speed",
+    "speed": "speed",
+    "spa": "sp_attack",
+    "spatk": "sp_attack",
+    "sp_atk": "sp_attack",
+    "specialattack": "sp_attack",
+    "spdef": "sp_defense",
+    "sp_def": "sp_defense",
+    "specialdefense": "sp_defense",
+}
+
+TRAINING_COST = 5
+
+"""This module handles user profiles, onboarding, and party management."""
+
+
+def ensure_user_record(uid: int) -> Dict:
+    """Ensure that a user record contains the latest structural fields."""
+    if uid not in USERS:
+        raise KeyError(f"User {uid} not found in database.")
+
+    user = USERS[uid]
+    changed = False
+
+    if user.get("uid") != uid:
+        user["uid"] = uid
+        changed = True
+    if "name" not in user:
+        user["name"] = str(uid)
+        changed = True
+    if "bp" not in user:
+        user["bp"] = 0
+        changed = True
+    if "items" not in user or not isinstance(user["items"], dict):
+        user["items"] = {}
+        changed = True
+    if "pokemon" not in user or not isinstance(user["pokemon"], list):
+        user["pokemon"] = []
+        changed = True
+
+    roster = user["pokemon"]
+    ids_seen = set()
+    for idx, data in enumerate(list(roster)):
+        mon = classes.Individual.from_dict(data)
+        if not mon:
+            continue
+        serialised = mon.to_dict()
+        if serialised != data:
+            roster[idx] = serialised
+            changed = True
+        ids_seen.add(serialised["uid"])
+
+    if "party" not in user or not isinstance(user["party"], list):
+        user["party"] = []
+        changed = True
+
+    filtered_party = [pid for pid in user["party"] if pid in ids_seen]
+    if filtered_party != user["party"]:
+        user["party"] = filtered_party
+        changed = True
+
+    if not user["party"] and roster:
+        user["party"] = [entry.get("uid") for entry in roster[:6] if entry.get("uid")]
+        changed = True
+
+    if "battles" not in user or not isinstance(user["battles"], list):
+        user["battles"] = []
+        changed = True
+
+    if changed:
+        USERS[uid] = user
+        USERS.save_item(uid)
+
+    return user
+
+
+def update_display_name(member) -> None:
+    """Persist the latest display name for leaderboard and embeds."""
+    if not member or member.id not in USERS:
+        return
+    display_name = getattr(member, "display_name", None) or getattr(member, "name", None)
+    if not display_name:
+        return
+    user = ensure_user_record(member.id)
+    if user.get("name") != display_name:
+        user["name"] = display_name
+        USERS[member.id] = user
+        USERS.save_item(member.id)
+
+
+def get_display_name(uid: int) -> str:
+    user = ensure_user_record(uid)
+    return user.get("name", str(uid))
+
+
+def roster_with_ids(uid: int) -> List[Tuple[str, classes.Individual]]:
+    user = ensure_user_record(uid)
+    roster: List[Tuple[str, classes.Individual]] = []
+    for data in user["pokemon"]:
+        mon = classes.Individual.from_dict(data)
+        if mon:
+            roster.append((mon.instance_id, mon))
+    return roster
+
+
+def get_party_members(uid: int) -> List[classes.Individual]:
+    user = ensure_user_record(uid)
+    roster_map = {mon_id: mon for mon_id, mon in roster_with_ids(uid)}
+    party_members: List[classes.Individual] = []
+    for mon_id in user.get("party", []):
+        mon = roster_map.get(mon_id)
+        if mon:
+            party_members.append(mon)
+    return party_members
+
+
+def add_to_party(uid: int, index: int) -> Tuple[bool, str]:
+    roster = roster_with_ids(uid)
+    if not roster:
+        return False, "You haven't caught any Pokémon yet. Try catching a wild one first!"
+    if index < 1 or index > len(roster):
+        return False, "That Pokémon index is out of range."
+    mon_id, mon = roster[index - 1]
+    user = ensure_user_record(uid)
+    if mon_id in user["party"]:
+        return False, f"{mon.get_title()} is already in your party."
+    if len(user["party"]) >= 6:
+        return False, "Your party is full. Remove a member first."
+    user["party"].append(mon_id)
+    USERS[uid] = user
+    USERS.save_item(uid)
+    return True, f"Added {mon.get_title()} to your party."
+
+
+def remove_from_party(uid: int, slot: int) -> Tuple[bool, str]:
+    user = ensure_user_record(uid)
+    party = user.get("party", [])
+    if not party:
+        return False, "Your party is already empty."
+    if slot < 1 or slot > len(party):
+        return False, "That party slot doesn't exist yet."
+    mon_id = party.pop(slot - 1)
+    removed_mon: Optional[classes.Individual] = None
+    for data in user["pokemon"]:
+        if data.get("uid") == mon_id:
+            removed_mon = classes.Individual.from_dict(data)
+            break
+    USERS[uid] = user
+    USERS.save_item(uid)
+    if removed_mon:
+        return True, f"Removed {removed_mon.get_title()} from your party."
+    return True, "Removed that party member."
+
+
+def swap_party_members(uid: int, slot_a: int, slot_b: int) -> Tuple[bool, str]:
+    user = ensure_user_record(uid)
+    party = user.get("party", [])
+    size = len(party)
+    if size < 2:
+        return False, "You need at least two party members to swap them."
+    if not (1 <= slot_a <= size and 1 <= slot_b <= size):
+        return False, "One of those party slots doesn't exist yet."
+    if slot_a == slot_b:
+        return False, "Those slots are the same Pokémon already."
+    party[slot_a - 1], party[slot_b - 1] = party[slot_b - 1], party[slot_a - 1]
+    USERS[uid] = user
+    USERS.save_item(uid)
+    return True, "Swapped those party members."
+
+
+def auto_fill_party(uid: int) -> Tuple[bool, str]:
+    roster = roster_with_ids(uid)
+    if not roster:
+        return False, "You haven't caught any Pokémon yet."
+    user = ensure_user_record(uid)
+    user["party"] = [mon_id for mon_id, _ in roster[:6]]
+    USERS[uid] = user
+    USERS.save_item(uid)
+    count = min(len(roster), 6)
+    return True, f"Filled your party with the first {count} Pokémon in your collection."
+
+
+def catch_pokemon(uid: int, mon: classes.Individual) -> None:
+    user = ensure_user_record(uid)
+    user.setdefault("pokemon", []).append(mon.to_dict())
+    if len(user.setdefault("party", [])) < 6:
+        user["party"].append(mon.instance_id)
+    USERS[uid] = user
+    USERS.save_item(uid)
+
+
+def _resolve_stat_key(token: str) -> Optional[str]:
+    if not token:
+        return None
+    normalised = token.replace("-", "").replace("_", "").lower()
+    return STAT_ALIASES.get(normalised)
+
+
+def train_pokemon(uid: int, slot: int, stat_key: str, sessions: int = 1) -> Tuple[bool, str, Optional[classes.Individual]]:
+    user = ensure_user_record(uid)
+    party = user.get("party", [])
+    if not party:
+        return False, "You don't have any Pokémon in your party yet.", None
+    if slot < 1 or slot > len(party):
+        return False, "That party slot doesn't exist yet.", None
+
+    mon_id = party[slot - 1]
+    roster = user.get("pokemon", [])
+    mon_index: Optional[int] = None
+    mon_obj: Optional[classes.Individual] = None
+    for idx, entry in enumerate(roster):
+        if entry.get("uid") == mon_id:
+            mon_index = idx
+            mon_obj = classes.Individual.from_dict(entry)
+            break
+    if mon_index is None or not mon_obj:
+        return False, "I couldn't find that Pokémon in your collection.", None
+
+    current = mon_obj.evs.get(stat_key, 0)
+    per_stat_cap = 252
+    remaining_stat_capacity = max(0, per_stat_cap - current)
+    remaining_total_capacity = mon_obj.remaining_ev_capacity()
+    if remaining_stat_capacity <= 0:
+        return False, f"{mon_obj.get_title()} has already maxed out {STAT_DISPLAY[stat_key]} training.", None
+    if remaining_total_capacity <= 0:
+        return False, f"{mon_obj.get_title()} has already reached the total EV limit.", None
+
+    sessions = max(1, int(sessions))
+    requested_gain = sessions * 4
+    gain_cap = min(remaining_stat_capacity, remaining_total_capacity)
+    gain = min(requested_gain, gain_cap)
+    if gain <= 0:
+        return False, f"{mon_obj.get_title()} can't gain any more EVs right now.", None
+
+    sessions_used = max(1, math.ceil(gain / 4))
+    cost = sessions_used * TRAINING_COST
+    if user.get("bp", 0) < cost:
+        plural = "s" if sessions_used != 1 else ""
+        return False, f"You need {cost} BP to run {sessions_used} training session{plural}.", None
+
+    mon_obj.evs[stat_key] = min(per_stat_cap, mon_obj.evs.get(stat_key, 0) + gain)
+    overflow = mon_obj.total_evs() - 510
+    if overflow > 0:
+        mon_obj.evs[stat_key] = max(0, mon_obj.evs[stat_key] - overflow)
+
+    user["bp"] = user.get("bp", 0) - cost
+    user["pokemon"][mon_index] = mon_obj.to_dict()
+    USERS[uid] = user
+    USERS.save_item(uid)
+
+    stat_name = STAT_DISPLAY[stat_key]
+    stats = mon_obj.get_stats()
+    message = (
+        f"Trained {mon_obj.get_title()} in {stat_name}! +{gain} EVs ({mon_obj.evs[stat_key]} total) "
+        f"for {cost} BP. {stat_name} is now {stats.get(stat_key, 0)}."
+    )
+    if mon_obj.remaining_ev_capacity() <= 0 or mon_obj.evs[stat_key] >= per_stat_cap:
+        message += " They can't train further in that area."
+
+    return True, message, mon_obj
+
+
+def adjust_bp(uid: int, delta: int) -> int:
+    user = ensure_user_record(uid)
+    user["bp"] = user.get("bp", 0) + delta
+    USERS[uid] = user
+    USERS.save_item(uid)
+    return user["bp"]
+
+
+def record_battle(uid: int, outcome: str, context: Dict) -> None:
+    if uid not in USERS:
+        return
+    user = ensure_user_record(uid)
+    entry = {"outcome": outcome, "context": context, "timestamp": time.time()}
+    user.setdefault("battles", []).append(entry)
+    user["battles"] = user["battles"][-50:]
+    USERS[uid] = user
+    USERS.save_item(uid)
+
+
+async def train_command(message, args: Sequence[str]):
+    uid = message.author.id
+    if uid not in USERS:
+        new_user(message.author)
+    ensure_user_record(uid)
+    update_display_name(message.author)
+
+    if len(args) < 2:
+        await message.reply(
+            "Use `!train <party slot> <stat> [sessions]`, for example `!train 1 attack 3`."
+        )
+        return
+
+    try:
+        slot = int(args[0])
+    except ValueError:
+        await message.reply("I couldn't understand that party slot number.")
+        return
+
+    stat_key = _resolve_stat_key(args[1])
+    if not stat_key:
+        await message.reply(
+            "I couldn't tell which stat you meant. Try HP, Attack, Defense, SpAtk, SpDef, or Speed."
+        )
+        return
+
+    sessions = 1
+    if len(args) >= 3:
+        try:
+            sessions = max(1, int(args[2]))
+        except ValueError:
+            await message.reply("I couldn't understand how many training sessions to run.")
+            return
+        sessions = min(sessions, 63)
+
+    success, response, mon = train_pokemon(uid, slot, stat_key, sessions)
+    if not success:
+        await message.reply(response)
+        return
+
+    embed = embeds.pokemon_summary(mon)
+    await message.reply(response, embed=embed)
+
+
+async def party_command(message, args: Sequence[str]):
+    uid = message.author.id
+    if uid not in USERS:
+        new_user(message.author)
+    ensure_user_record(uid)
+    update_display_name(message.author)
+
+    response = ""
+    if not args:
+        response = "Use `!party add <number>` to move a Pokémon from your collection into your party."
+    else:
+        action = args[0].lower()
+        if action == "add" and len(args) >= 2:
+            try:
+                index = int(args[1])
+            except ValueError:
+                response = "I couldn't understand that collection number."
+            else:
+                _, response = add_to_party(uid, index)
+        elif action in {"remove", "rm", "drop"} and len(args) >= 2:
+            try:
+                slot = int(args[1])
+            except ValueError:
+                response = "I couldn't understand that party slot."
+            else:
+                _, response = remove_from_party(uid, slot)
+        elif action == "swap" and len(args) >= 3:
+            try:
+                slot_a = int(args[1])
+                slot_b = int(args[2])
+            except ValueError:
+                response = "I couldn't understand one of those party slots."
+            else:
+                _, response = swap_party_members(uid, slot_a, slot_b)
+        elif action in {"auto", "fill"}:
+            _, response = auto_fill_party(uid)
+        else:
+            response = "Try `!party`, `!party add 3`, `!party remove 1`, `!party swap 1 3`, or `!party auto`."
+
+    party_members = get_party_members(uid)
+    roster_members = [mon for _, mon in roster_with_ids(uid)]
+    embed = embeds.party(message.author, party_members, roster_members, note=response)
+    await message.reply(embed=embed)
+
 
 async def profile(message):
     """Show a profile, making a new user if needed."""
@@ -11,24 +401,30 @@ async def profile(message):
     if message.author.id not in USERS:
         new_user(message.author)
         new = True
+    ensure_user_record(message.author.id)
+    update_display_name(message.author)
     tosay = "Welcome to the community!" if new else ""
-    await message.reply(tosay, embed = embeds.profile(message.author))
+    await message.reply(tosay, embed=embeds.profile(message.author))
 
 
-def new_user(user):
-    # Possibly using a class in addition to this 
+def new_user(user) -> None:
+    # Possibly using a class in addition to this
     # might help with if i ever must change the user struct?
     u = {}
     u["uid"] = user.id
-    
+
+    # Persist a readable name for embeds such as leaderboards.
+    display_name = getattr(user, "display_name", None) or getattr(user, "name", None)
+    u["name"] = display_name or str(user.id)
+
     u["bp"] = 0
-    
+
     u["items"] = {"pokeball": 5}
-    
+
     u["pokemon"] = []
-    
-    
+    u["party"] = []
+
     u["battles"] = []
-    
+
     USERS[user.id] = u
-    
+    USERS.save_item(user.id)


### PR DESCRIPTION
## Summary
- add bundled Pokédex entries and shop item data so species, items, and user saves persist without external files
- introduce a reusable move catalogue plus XP/evolution tracking in individual Pokémon models
- rebuild battles as reaction-driven, turn-based sessions with status effects, items, XP rewards, and updated embeds/commands for trainer and wild fights

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_690bc918d240832abec70774e1199b9b